### PR TITLE
fix: null check currentTab

### DIFF
--- a/background.js
+++ b/background.js
@@ -32,7 +32,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, change, tab) {
 
 chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
   var currentTab = tabs[0];
-  if (currentTab !== undefined || currentTab !== null) return;
+  if (!currentTab || !currentTab.url) return;
 
   if (isGitHubIssueUrl(currentTab.url)) {
     updateBranchName(currentTab.id);


### PR DESCRIPTION
Looking over the code I realized that the original if condition always evaluated to true because currentTab would also not be undefined OR not be null. This updates the gating to what I imagine is the original intention, but I wasn't sure how to console log of test the code to verify that I understand the purpose.